### PR TITLE
h264_sei.c: parse multiple SEI messages properly

### DIFF
--- a/h264_sei.c
+++ b/h264_sei.c
@@ -69,7 +69,7 @@ void read_sei_payload(h264_stream_t* h, bs_t* b, int payloadType, int payloadSiz
     for ( i = 0; i < payloadSize; i++ )
         s->payload[i] = bs_read_u(b, 8);
         
-    read_sei_end_bits(h, b);
+    //read_sei_end_bits(h, b);
 }
 
 // D.1 SEI payload syntax


### PR DESCRIPTION
SEI NALU containing multiple messages: 00 00 00 01 06 01 01 04 04 09 b5 00 31 44 54 47 31 41  f8 06 01 84 80

read_sei_payload currently invokes read_sei_end_bits, ultimately invoking read_rbsp_trailing_bits after parsing a single message. However, h264_read_sei_rbsp in h264_stream.c invokes this function multiple times to read every SEI message inside the SEI NALU. h264_read_rbsp_trailing_bits is invoked after that loop, and it's clear that's the proper place for it to be called, rather than after reading each individual SEI message.

The impact of the bug is that h264_analyze dumps a garbled description of subsequent SEI messages when more than one is present, as the payload type and size for each is read from the wrong bytes. Commenting out this one line has fixed the issue for me locally, but I don't have the understanding of the entire project required to determine if this change fixes one issue but breaks the intentions of the code elsewhere.

Thanks for the project by the way, it is awesome!
