### PR TITLE
Fix segfault when a PPS has a scaling matix

### DIFF
--- a/h264_stream.h
+++ b/h264_stream.h
@@ -60,9 +60,9 @@ typedef struct
     int qpprime_y_zero_transform_bypass_flag;
     int seq_scaling_matrix_present_flag;
       int seq_scaling_list_present_flag[8];
-      int* ScalingList4x4[6][16];
+      int ScalingList4x4[6][16];
       int UseDefaultScalingMatrix4x4Flag[6];
-      int* ScalingList8x8[2][64];
+      int ScalingList8x8[2][64];
       int UseDefaultScalingMatrix8x8Flag[2];
     int log2_max_frame_num_minus4;
     int pic_order_cnt_type;

--- a/h264_stream.h
+++ b/h264_stream.h
@@ -178,9 +178,9 @@ typedef struct
     int transform_8x8_mode_flag;
     int pic_scaling_matrix_present_flag;
        int pic_scaling_list_present_flag[8];
-       int* ScalingList4x4[6];
+       int ScalingList4x4[6][16];
        int UseDefaultScalingMatrix4x4Flag[6];
-       int* ScalingList8x8[2];
+       int ScalingList8x8[2][64];
        int UseDefaultScalingMatrix8x8Flag[2];
     int second_chroma_qp_index_offset;
 } pps_t;


### PR DESCRIPTION
Sorry for that, in my last pull request I forgot to remove some '*' actually using pointers to store ints. It works thanks to implicit conversions but you may want the clean version.