### PR TITLE
Fix scaling list parsing when chroma_format_idc is equal to 3

### DIFF
--- a/h264_stream.c
+++ b/h264_stream.c
@@ -393,7 +393,7 @@ void read_seq_parameter_set_rbsp(sps_t* sps, bs_t* b)
         sps->seq_scaling_matrix_present_flag = bs_read_u1(b);
         if( sps->seq_scaling_matrix_present_flag )
         {
-            for( i = 0; i < 8; i++ )
+            for( i = 0; i < ((sps->chroma_format_idc != 3) ? 8 : 12); i++ )
             {
                 sps->seq_scaling_list_present_flag[ i ] = bs_read_u1(b);
                 if( sps->seq_scaling_list_present_flag[ i ] )

--- a/h264_stream.h
+++ b/h264_stream.h
@@ -74,11 +74,11 @@ typedef struct
     int bit_depth_chroma_minus8;
     int qpprime_y_zero_transform_bypass_flag;
     int seq_scaling_matrix_present_flag;
-      int seq_scaling_list_present_flag[8];
+      int seq_scaling_list_present_flag[12];
       int ScalingList4x4[6][16];
       int UseDefaultScalingMatrix4x4Flag[6];
-      int ScalingList8x8[2][64];
-      int UseDefaultScalingMatrix8x8Flag[2];
+      int ScalingList8x8[6][64];
+      int UseDefaultScalingMatrix8x8Flag[6];
     int log2_max_frame_num_minus4;
     int pic_order_cnt_type;
     int log2_max_pic_order_cnt_lsb_minus4;


### PR DESCRIPTION
In this case we can have up to 12 scaling list according to specification
section 7.3.2.1.1.