### PR TITLE
fix build with g++ : error: ‘sei_scalability_priority_layer_info_t’ does not name a type

### DIFF
--- a/h264_sei.h
+++ b/h264_sei.h
@@ -110,8 +110,6 @@ typedef struct
 
 #define MAX_LENGTH 128
 
-typedef  sei_scalability_priority_layer_info_t;
-
 typedef struct
 {
     bool temporal_id_nesting_flag;


### PR DESCRIPTION
Trying to compile a simple main like : 
```
#include "h264_stream.h"
int main() {
	return 0;
}
```
Fails with the error : 

> In file included from h264_stream.h:31:0,
>                  from test.cpp:1:
> h264_sei.h:113:10: error: ‘sei_scalability_priority_layer_info_t’ does not name a type; did you mean ‘sei_scalability_layer_info_t’?
>  typedef  sei_scalability_priority_layer_info_t;
>           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>           sei_scalability_layer_info_t

This pull request remove the typedef that seems an old forward declaration.

Best Regards
Michel.
