### PR TITLE
fix(h264_analyze): fix incorrect parse for duplicate startcode

### DIFF
--- a/h264_analyze.c
+++ b/h264_analyze.c
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
 
         sz += rsz;
 
-        while (find_nal_unit(p, sz, &nal_start, &nal_end) > 0)
+        while (find_nal_unit(p, sz, &nal_start, &nal_end) >= 0)
         {
             if ( opt_verbose > 0 )
             {


### PR DESCRIPTION
Fix parsing error when duplicate 00 00 00 01 occurs.
For example
00 00 00 01 00 00 00 01
Original code will bypass first startcode but not modify "p"
and "sz", which result in parse error.