### PR TITLE
Buildscripts/cmake uninstall target

### DIFF
--- a/.github/workflows/cmake-install-uninstall.yml
+++ b/.github/workflows/cmake-install-uninstall.yml
@@ -1,4 +1,4 @@
-name: CMake CI on Ubuntu
+name: CMake Install & Uninstall
 
 on:
   push:
@@ -23,7 +23,7 @@ jobs:
 
     - name: Configure CMake
       run: |
-        cmake -S . -B .build
+        cmake -S . -B .build -DCMAKE_BUILD_TYPE=Release
 
     - name: Build CMake
       run: |

--- a/.github/workflows/cmake-install-uninstall.yml
+++ b/.github/workflows/cmake-install-uninstall.yml
@@ -1,0 +1,38 @@
+name: CMake CI on Ubuntu
+
+on:
+  push:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      run: |
+        cmake -S . -B .build
+
+    - name: Build CMake
+      run: |
+        cmake --build .build --config Release
+    
+    - name: Install
+      run: |
+        cmake --install .build --prefix .install
+
+    - name: Uninstall
+      run: |
+        cmake --build .build --target uninstall

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,8 @@ install(TARGETS h264bitstream h264_analyze svc_split
 	FILE_SET headers
 )
 
+# Support for pkg-config in consuming projects
 if(UNIX)
-	# Support for pkg-config in consuming projects
 	set(prefix "${CMAKE_INSTALL_PREFIX}")
 	set(exec_prefix "${CMAKE_INSTALL_PREFIX}")
 	set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
@@ -74,3 +74,15 @@ if(UNIX)
 		DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig"
 	)
 endif(UNIX)
+
+# uninstall target
+if(NOT TARGET uninstall)
+	configure_file(
+		"${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+		"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+		IMMEDIATE @ONLY
+	)
+	add_custom_target(uninstall
+		COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
+	)
+endif()

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ All commands below should be run from the project root directory.
           └── libh264bitstream.pc
   ```
 
+  CMake doesn't support `make uninstall` by default. But the project has the `uninstall` target, which deletes all files listed in `install_manifest.txt` file. To use it, run:
+  
+  ```sh
+  cmake --build .builddir --target uninstall
+  ```
+
 ## Compile and Install with Autotools
 
 1. Install pre-requisites (Debian, Ubuntu)

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -9,11 +9,10 @@ foreach(file ${files})
 	if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
 		execute_process(
 			COMMAND "@CMAKE_COMMAND@" -E rm "$ENV{DESTDIR}${file}"
-			OUTPUT_VARIABLE rm_out
 			RESULT_VARIABLE rm_retval
 		)
 		if(NOT "${rm_retval}" STREQUAL 0)
-		  message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+			message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
 		endif()
 	else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
 		message(STATUS "File $ENV{DESTDIR}${file} does not exist.")

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+	message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+	message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+	if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+		execute_process(
+			COMMAND "@CMAKE_COMMAND@" -E rm "$ENV{DESTDIR}${file}"
+			OUTPUT_VARIABLE rm_out
+			RESULT_VARIABLE rm_retval
+		)
+		if(NOT "${rm_retval}" STREQUAL 0)
+		  message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+		endif()
+	else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+		message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+	endif()
+endforeach()


### PR DESCRIPTION
_CMake_ doesn't support any `make uninstall` commands by default. This may be embarrassing for users, switching from building with `autotools`. This PR adds a special `uninstall` target to do the deinstallation process.

During `cmake --install` step, an `install_manifest.txt` file is created, which contains a list of installed files -- binaries, libraries, headers and so on. The `uninstall` target calls `cmake -E rm` for every file listed in this manifest. Simple and handy.

To launch the deinstallation process, one can run:
```sh
cmake --build .builddir --target uninstall
```
The information in _README.md_ is updated. An additional workflow is added, which smoke-tests the installation/deinstallation process.