### PR TITLE
Allocate avcc->pps_table with the num of PPS, not the num of SPS

### DIFF
--- a/h264_avcc.c
+++ b/h264_avcc.c
@@ -48,7 +48,7 @@ int read_avcc(avcc_t* avcc, h264_stream_t* h, bs_t* b)
   }
 
   avcc->numOfPictureParameterSets = bs_read_u(b, 8);
-  avcc->pps_table = (pps_t**)calloc(avcc->numOfSequenceParameterSets, sizeof(pps_t*));
+  avcc->pps_table = (pps_t**)calloc(avcc->numOfPictureParameterSets, sizeof(pps_t*));
   for (int i = 0; i < avcc->numOfPictureParameterSets; i++)
   {
     int pictureParameterSetLength = bs_read_u(b, 16);


### PR DESCRIPTION
This is a fix for #57 where `avcc->pps_table` was being allocated using the number of SPS instead of the number of PPS, causing an out-of-bounds situation when the number of PPS is greater than the number of SPS.

Built the project as a sanity check.