### PR TITLE
Make read_pic_parameter_set_rbsp() take pps_t instead of h264_stream_t

### DIFF
--- a/h264_stream.c
+++ b/h264_stream.c
@@ -137,7 +137,7 @@ void read_seq_parameter_set_svc_extension(sps_subset_t* sps_subset, bs_t* b);
 void read_svc_vui_parameters_extension(sps_svc_ext_t* sps_svc_ext, bs_t* b);
 void read_vui_parameters(sps_t* sps, bs_t* b);
 void read_hrd_parameters(hrd_t* hrd, bs_t* b);
-void read_pic_parameter_set_rbsp(h264_stream_t* h, bs_t* b);
+void read_pic_parameter_set_rbsp(pps_t* pps, bs_t* b);
 void read_sei_rbsp(h264_stream_t* h, bs_t* b);
 void read_sei_message(h264_stream_t* h, bs_t* b);
 void read_access_unit_delimiter_rbsp(h264_stream_t* h, bs_t* b);
@@ -226,8 +226,14 @@ int read_nal_unit(h264_stream_t* h, uint8_t* buf, int size)
             break;
 
         case NAL_UNIT_TYPE_PPS:   
-            read_pic_parameter_set_rbsp(h, b);
+            read_pic_parameter_set_rbsp(h->pps, b);
             read_rbsp_trailing_bits(b);
+
+            if( 1 )
+            {
+                memcpy(h->pps_table[h->pps->pic_parameter_set_id], h->pps, sizeof(pps_t));
+            }
+
             break;
 
         case NAL_UNIT_TYPE_AUD:     
@@ -704,9 +710,8 @@ int read_seq_parameter_set_extension_rbsp(bs_t* b, sps_ext_t* sps_ext) {
 */
 
 //7.3.2.2 Picture parameter set RBSP syntax
-void read_pic_parameter_set_rbsp(h264_stream_t* h, bs_t* b)
+void read_pic_parameter_set_rbsp(pps_t* pps, bs_t* b)
 {
-    pps_t* pps = h->pps;
     if( 1 )
     {
         memset(pps, 0, sizeof(pps_t));
@@ -796,11 +801,6 @@ void read_pic_parameter_set_rbsp(h264_stream_t* h, bs_t* b)
             }
         }
         pps->second_chroma_qp_index_offset = bs_read_se(b);
-    }
-
-    if( 1 )
-    {
-        memcpy(h->pps_table[pps->pic_parameter_set_id], h->pps, sizeof(pps_t));
     }
 }
 
@@ -2797,7 +2797,7 @@ void read_debug_seq_parameter_set_svc_extension(sps_subset_t* sps_subset, bs_t* 
 void read_debug_svc_vui_parameters_extension(sps_svc_ext_t* sps_svc_ext, bs_t* b);
 void read_debug_vui_parameters(sps_t* sps, bs_t* b);
 void read_debug_hrd_parameters(hrd_t* hrd, bs_t* b);
-void read_debug_pic_parameter_set_rbsp(h264_stream_t* h, bs_t* b);
+void read_debug_pic_parameter_set_rbsp(pps_t* pps, bs_t* b);
 void read_debug_sei_rbsp(h264_stream_t* h, bs_t* b);
 void read_debug_sei_message(h264_stream_t* h, bs_t* b);
 void read_debug_access_unit_delimiter_rbsp(h264_stream_t* h, bs_t* b);
@@ -2886,8 +2886,14 @@ int read_debug_nal_unit(h264_stream_t* h, uint8_t* buf, int size)
             break;
 
         case NAL_UNIT_TYPE_PPS:   
-            read_debug_pic_parameter_set_rbsp(h, b);
+            read_debug_pic_parameter_set_rbsp(h->pps, b);
             read_debug_rbsp_trailing_bits(b);
+
+            if( 1 )
+            {
+                memcpy(h->pps_table[h->pps->pic_parameter_set_id], h->pps, sizeof(pps_t));
+            }
+
             break;
 
         case NAL_UNIT_TYPE_AUD:     
@@ -3362,9 +3368,8 @@ int read_debug_seq_parameter_set_extension_rbsp(bs_t* b, sps_ext_t* sps_ext) {
 */
 
 //7.3.2.2 Picture parameter set RBSP syntax
-void read_debug_pic_parameter_set_rbsp(h264_stream_t* h, bs_t* b)
+void read_debug_pic_parameter_set_rbsp(pps_t* pps, bs_t* b)
 {
-    pps_t* pps = h->pps;
     if( 1 )
     {
         memset(pps, 0, sizeof(pps_t));
@@ -3454,11 +3459,6 @@ void read_debug_pic_parameter_set_rbsp(h264_stream_t* h, bs_t* b)
             }
         }
         printf("%ld.%d: ", (long int)(b->p - b->start), b->bits_left); pps->second_chroma_qp_index_offset = bs_read_se(b); printf("pps->second_chroma_qp_index_offset: %d \n", pps->second_chroma_qp_index_offset); 
-    }
-
-    if( 1 )
-    {
-        memcpy(h->pps_table[pps->pic_parameter_set_id], h->pps, sizeof(pps_t));
     }
 }
 

--- a/h264_stream.h
+++ b/h264_stream.h
@@ -542,7 +542,7 @@ void read_scaling_list(bs_t* b, int* scalingList, int sizeOfScalingList, int* us
 void read_vui_parameters(sps_t* sps, bs_t* b);
 void read_hrd_parameters(hrd_t* hrd, bs_t* b);
 
-void read_pic_parameter_set_rbsp(h264_stream_t* h, bs_t* b);
+void read_pic_parameter_set_rbsp(pps_t* pps, bs_t* b);
 
 void read_sei_rbsp(h264_stream_t* h, bs_t* b);
 void read_sei_message(h264_stream_t* h, bs_t* b);


### PR DESCRIPTION
## Change descrption

This change allows `read_pic_parameter_set_rbsp()` (and `read_debug_pic_parameter_set_rbsp()`) to be used without a `h264_stream_t` instance. Instead, only the `pps_t` instance is required. A `memcpy()` operation inside `read_pic_parameter_set_rbsp()` was moved to `read_nal_unit()`. This brings the function in line with `read_seq_parameter_set_rbsp()` which operates the same way.

### Breaking API change

Because this change introduces a breaking API change, semantic versioning would require a major version bump. If this is undesirable, the changed functions could remain as-is and a new function named something like `read_pic_parameter_set_rbsp_only(pps_t*, bs_t*)` could be introduced, requiring only a minor version bump.

## Testing

I'm not sure if there is a format testing protocol for this repo. I compared the before/after output of the `h264_analyze` tool on the various samples within the repo.

```
<build current version>

$ ./h264_analyze -v 1 samples/JM_cqm_cabac.264 > JM_before.txt
$ ./h264_analyze -v 1 samples/riverbed-II-360p-48961.264 > riverbed_before.txt
$ ./h264_analyze -v 1 samples/x264_test.264 > x264_before.txt

<build modified version>

$ ./h264_analyze -v 1 samples/JM_cqm_cabac.264 > JM_after.txt
$ ./h264_analyze -v 1 samples/riverbed-II-360p-48961.264 > riverbed_after.txt
$ ./h264_analyze -v 1 samples/x264_test.264 > x264_after.txt

$ diff JM_before.txt JM_after.txt
<empty>
$ diff riverbed_before.txt riverbed_after.txt
<empty>
$ diff x264_before.txt x264_after.txt
<empty>
```